### PR TITLE
E2E test

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,0 +1,82 @@
+name: E2E test
+
+on:
+  schedule:
+    # Friday 06:00 UTC (Friday 15:00 JST)
+    - cron: '0 6 * * 5'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch"
+        required: true
+        default: "develop"
+
+concurrency:
+  group: ${{ github.head_ref || github.ref_name }}-e2e
+  cancel-in-progress: true
+
+env:
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g"
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - uses: ./.github/actions/setup-gradle
+        with:
+          use-build-cache: 'true'
+      - uses: ./.github/actions/sunsetscrob-setup
+        with:
+          last-fm-api-key: ${{ secrets.LAST_FM_API_KEY }}
+          last-fm-shared-secret: ${{ secrets.LAST_FM_SHARED_SECRET }}
+          google-services-json: ${{ secrets.GOOGLE_SERVICES_JSON_DEV }}
+
+      - name: AVD cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-api35-x86_64
+
+      - name: Create AVD snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
+        with:
+          api-level: 35
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: echo "Generated AVD snapshot."
+
+      - name: Run E2E tests
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
+        with:
+          api-level: 35
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: ./gradlew :app:connectedDebugAndroidTest
+
+      - name: Upload test reports
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-test-reports
+          path: |
+            **/build/reports/androidTests/**
+            **/build/outputs/androidTest-results/**
+          retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Refer to the following documents only when needed:
 | `@docs/coding-conventions.md` | Naming conventions, Compose guidelines | When writing code |
 | `@DESIGN.md` | Visual identity, theme intent, UI component conventions | When implementing or modifying UI |
 | `@docs/testing.md` | Unit Test, Screenshot Test guidelines | When writing tests |
+| `@docs/e2e-testing.md` | E2E (instrumentation) test architecture, fixture mocking, weekly CI | When adding fixtures, smoke flows, or touching `app/src/androidTest/` |
 
 ## Project Overview
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,6 +17,16 @@ configure<ApplicationExtension>() {
   }
 
   namespace = "com.mataku.scrobscrob"
+
+  defaultConfig {
+    testInstrumentationRunner = "com.mataku.scrobscrob.app.testing.MetroTestRunner"
+  }
+
+  sourceSets {
+    getByName("androidTest") {
+      assets.srcDirs("src/test/assets", "src/androidTest/assets")
+    }
+  }
 }
 
 dependencies {
@@ -57,6 +67,14 @@ dependencies {
 
   implementation(libs.coil.compose)
   implementation(libs.coil.okhttp)
+
+  androidTestImplementation(libs.androidx.test.ext.junit)
+  androidTestImplementation(libs.androidx.test.runner)
+  androidTestImplementation(libs.compose.ui.test.junit4)
+  androidTestImplementation(libs.compose.ui.test.android)
+  androidTestImplementation(libs.ktor.client.mock)
+  androidTestImplementation(libs.coroutines.test)
+  debugImplementation(libs.compose.ui.test.manifest)
 }
 
 ksp {

--- a/app/src/androidTest/assets/chart_top_artists.json
+++ b/app/src/androidTest/assets/chart_top_artists.json
@@ -1,0 +1,42 @@
+{
+  "artists": {
+    "artist": [
+      {
+        "name": "The Weeknd",
+        "playcount": "578258095",
+        "listeners": "3680672",
+        "mbid": "c8b03190-306c-4120-bb0b-6f2ebfc06ea9",
+        "url": "https://www.last.fm/music/The+Weeknd",
+        "streamable": "0",
+        "image": [
+          {
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png",
+            "size": "small"
+          },
+          {
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png",
+            "size": "medium"
+          },
+          {
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png",
+            "size": "large"
+          },
+          {
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png",
+            "size": "extralarge"
+          },
+          {
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png",
+            "size": "mega"
+          }
+        ]
+      }
+    ],
+    "@attr": {
+      "page": "1",
+      "perPage": "1",
+      "totalPages": "1",
+      "total": "1"
+    }
+  }
+}

--- a/app/src/androidTest/assets/chart_top_tracks.json
+++ b/app/src/androidTest/assets/chart_top_tracks.json
@@ -1,0 +1,47 @@
+{
+  "tracks": {
+    "track": [
+      {
+        "name": "My Love Mine All Mine",
+        "duration": "0",
+        "playcount": "16319592",
+        "listeners": "843008",
+        "mbid": "",
+        "url": "https://www.last.fm/music/Mitski/_/My+Love+Mine+All+Mine",
+        "streamable": {
+          "#text": "0",
+          "fulltrack": "0"
+        },
+        "artist": {
+          "name": "Mitski",
+          "mbid": "fa58cf24-0e44-421d-8519-8bf461dcfaa5",
+          "url": "https://www.last.fm/music/Mitski"
+        },
+        "image": [
+          {
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png",
+            "size": "small"
+          },
+          {
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png",
+            "size": "medium"
+          },
+          {
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png",
+            "size": "large"
+          },
+          {
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png",
+            "size": "extralarge"
+          }
+        ]
+      }
+    ],
+    "@attr": {
+      "page": "1",
+      "perPage": "1",
+      "totalPages": "1",
+      "total": "1"
+    }
+  }
+}

--- a/app/src/androidTest/assets/user_get_info.json
+++ b/app/src/androidTest/assets/user_get_info.json
@@ -1,0 +1,40 @@
+{
+  "user": {
+    "name": "e2e_user",
+    "age": "0",
+    "subscriber": "1",
+    "realname": "e2e",
+    "bootstrap": "0",
+    "playcount": "102654",
+    "artist_count": "728",
+    "playlists": "0",
+    "track_count": "2296",
+    "album_count": "1753",
+    "image": [
+      {
+        "size": "small",
+        "#text": "https://lastfm.freetls.fastly.net/i/u/34s/3605caa7a395e19202c55d55be23cbff.png"
+      },
+      {
+        "size": "medium",
+        "#text": "https://lastfm.freetls.fastly.net/i/u/64s/3605caa7a395e19202c55d55be23cbff.png"
+      },
+      {
+        "size": "large",
+        "#text": "https://lastfm.freetls.fastly.net/i/u/174s/3605caa7a395e19202c55d55be23cbff.png"
+      },
+      {
+        "size": "extralarge",
+        "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/3605caa7a395e19202c55d55be23cbff.png"
+      }
+    ],
+    "registered": {
+      "unixtime": "1483283210",
+      "#text": 1483283210
+    },
+    "country": "None",
+    "gender": "n",
+    "url": "https://www.last.fm/user/e2e_user",
+    "type": "subscriber"
+  }
+}

--- a/app/src/androidTest/assets/user_loved_tracks.json
+++ b/app/src/androidTest/assets/user_loved_tracks.json
@@ -1,0 +1,1813 @@
+{
+  "lovedtracks": {
+    "track": [
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/Team+ahamo(%E5%A4%A9%E5%AE%AE%E3%81%93%E3%81%93%E3%82%8D%2F%E6%A9%98%E3%81%B2%E3%81%AA%E3%81%AE%2F%E3%82%A2%E3%83%AB%E3%82%B9%E3%83%BB%E3%82%A2%E3%83%AB%E3%83%9E%E3%83%AB%2F%E5%A4%8F%E8%89%B2%E3%81%BE%E3%81%A4%E3%82%8A%2F%E5%B0%BE%E4%B8%B8%E3%83%9D%E3%83%AB%E3%82%AB)",
+          "name": "Team ahamo(天宮こころ/橘ひなの/アルス・アルマル/夏色まつり/尾丸ポルカ)",
+          "mbid": ""
+        },
+        "date": {
+          "uts": "1733642410",
+          "#text": "08 Dec 2024, 07:20"
+        },
+        "mbid": "",
+        "url": "https://www.last.fm/music/Team+ahamo(%E5%A4%A9%E5%AE%AE%E3%81%93%E3%81%93%E3%82%8D%2F%E6%A9%98%E3%81%B2%E3%81%AA%E3%81%AE%2F%E3%82%A2%E3%83%AB%E3%82%B9%E3%83%BB%E3%82%A2%E3%83%AB%E3%83%9E%E3%83%AB%2F%E5%A4%8F%E8%89%B2%E3%81%BE%E3%81%A4%E3%82%8A%2F%E5%B0%BE%E4%B8%B8%E3%83%9D%E3%83%AB%E3%82%AB)/_/Boom",
+        "name": "Boom",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/Midnight+Grand+Orchestra",
+          "name": "Midnight Grand Orchestra",
+          "mbid": "337a25b8-2ffc-40b6-a4b7-22dbfe5b1ecd"
+        },
+        "date": {
+          "uts": "1733642356",
+          "#text": "08 Dec 2024, 07:19"
+        },
+        "mbid": "205bb4b7-4492-4b81-949d-87bf5ef8062b",
+        "url": "https://www.last.fm/music/Midnight+Grand+Orchestra/_/Midnight+Mission",
+        "name": "Midnight Mission",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/Hitsujibungaku",
+          "name": "Hitsujibungaku",
+          "mbid": ""
+        },
+        "date": {
+          "uts": "1721909960",
+          "#text": "25 Jul 2024, 12:19"
+        },
+        "mbid": "",
+        "url": "https://www.last.fm/music/Hitsujibungaku/_/more+than+words",
+        "name": "more than words",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/IZ*ONE",
+          "name": "IZ*ONE",
+          "mbid": "49948ebe-bf1c-4823-b470-f2c9ab018686"
+        },
+        "date": {
+          "uts": "1656254164",
+          "#text": "26 Jun 2022, 14:36"
+        },
+        "mbid": "29b1598c-b8c9-4b5e-8579-a3e3e23f5d8b",
+        "url": "https://www.last.fm/music/IZ*ONE/_/Panorama",
+        "name": "Panorama",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/aespa",
+          "name": "aespa",
+          "mbid": "b51c672b-85e0-48fe-8648-470a2422229f"
+        },
+        "date": {
+          "uts": "1656254160",
+          "#text": "26 Jun 2022, 14:36"
+        },
+        "mbid": "b7234d30-0a97-453a-9638-41ad36fddf12",
+        "url": "https://www.last.fm/music/aespa/_/ICONIC",
+        "name": "ICONIC",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/aespa",
+          "name": "aespa",
+          "mbid": "b51c672b-85e0-48fe-8648-470a2422229f"
+        },
+        "date": {
+          "uts": "1656254158",
+          "#text": "26 Jun 2022, 14:35"
+        },
+        "mbid": "85a66da6-145d-47c7-ad5c-e4cd8273fe08",
+        "url": "https://www.last.fm/music/aespa/_/Savage",
+        "name": "Savage",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/aespa",
+          "name": "aespa",
+          "mbid": "b51c672b-85e0-48fe-8648-470a2422229f"
+        },
+        "date": {
+          "uts": "1656254157",
+          "#text": "26 Jun 2022, 14:35"
+        },
+        "mbid": "209310f1-e6fc-49e3-b233-d4220f8baeb8",
+        "url": "https://www.last.fm/music/aespa/_/Dreams+Come+True",
+        "name": "Dreams Come True",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/aespa",
+          "name": "aespa",
+          "mbid": "b51c672b-85e0-48fe-8648-470a2422229f"
+        },
+        "date": {
+          "uts": "1656254154",
+          "#text": "26 Jun 2022, 14:35"
+        },
+        "mbid": "3535d3ce-5dfd-4613-b35a-fcc3f7ada553",
+        "url": "https://www.last.fm/music/aespa/_/Life%27s+Too+Short+(English+Version)",
+        "name": "Life's Too Short (English Version)",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/PassCode",
+          "name": "PassCode",
+          "mbid": "2b875bcd-6f09-4b70-87fc-17d3f17e6097"
+        },
+        "date": {
+          "uts": "1605622100",
+          "#text": "17 Nov 2020, 14:08"
+        },
+        "mbid": "0a5848fd-3735-49d4-bbed-d0ab83ff2f61",
+        "url": "https://www.last.fm/music/PassCode/_/Anything+New",
+        "name": "Anything New",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/SixTONES",
+          "name": "SixTONES",
+          "mbid": "47a3fb29-e36b-440b-9d3c-3a68cec34396"
+        },
+        "date": {
+          "uts": "1600003209",
+          "#text": "13 Sep 2020, 13:20"
+        },
+        "mbid": "103d1de8-e383-415b-b707-69f337985cd0",
+        "url": "https://www.last.fm/music/SixTONES/_/NAVIGATOR",
+        "name": "NAVIGATOR",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246",
+          "name": "乃木坂46",
+          "mbid": "466f7b0a-a3e6-435d-8326-b4ef825a609d"
+        },
+        "date": {
+          "uts": "1600003205",
+          "#text": "13 Sep 2020, 13:20"
+        },
+        "mbid": "63fe5b02-c245-4421-9546-499c204e27a2",
+        "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246/_/%E3%82%AD%E3%83%A3%E3%83%A9%E3%83%90%E3%83%B3%E3%81%AF%E7%9C%A0%E3%82%89%E3%81%AA%E3%81%84",
+        "name": "キャラバンは眠らない",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/Power+Music+Workout",
+          "name": "Power Music Workout",
+          "mbid": ""
+        },
+        "date": {
+          "uts": "1576412555",
+          "#text": "15 Dec 2019, 12:22"
+        },
+        "mbid": "",
+        "url": "https://www.last.fm/music/Power+Music+Workout/_/Problem+-+Workout+Mix",
+        "name": "Problem - Workout Mix",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/PassCode",
+          "name": "PassCode",
+          "mbid": "2b875bcd-6f09-4b70-87fc-17d3f17e6097"
+        },
+        "date": {
+          "uts": "1576412547",
+          "#text": "15 Dec 2019, 12:22"
+        },
+        "mbid": "8bfb50a9-73dd-4108-ac5e-0de665634e1c",
+        "url": "https://www.last.fm/music/PassCode/_/Future%27s+Near+By",
+        "name": "Future's Near By",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/Afrojack",
+          "name": "Afrojack",
+          "mbid": "a3ee920f-4e7f-4993-8aca-4b8538cfaa4a"
+        },
+        "date": {
+          "uts": "1537173361",
+          "#text": "17 Sep 2018, 08:36"
+        },
+        "mbid": "185b377f-4436-4bb7-af49-168f3e7cc43f",
+        "url": "https://www.last.fm/music/Afrojack/_/Bassride",
+        "name": "Bassride",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246",
+          "name": "乃木坂46",
+          "mbid": "466f7b0a-a3e6-435d-8326-b4ef825a609d"
+        },
+        "date": {
+          "uts": "1535292973",
+          "#text": "26 Aug 2018, 14:16"
+        },
+        "mbid": "00d4ede9-1a33-437c-890b-c5f8f6a9c856",
+        "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246/_/%E7%A9%BA%E6%89%89",
+        "name": "空扉",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E3%83%AB%E3%83%87%E3%82%A3%E3%83%A1%E3%83%B3%E3%82%BF%E3%83%AB+&+Major+Lazer",
+          "name": "ルディメンタル & Major Lazer",
+          "mbid": ""
+        },
+        "date": {
+          "uts": "1535292967",
+          "#text": "26 Aug 2018, 14:16"
+        },
+        "mbid": "",
+        "url": "https://www.last.fm/music/%E3%83%AB%E3%83%87%E3%82%A3%E3%83%A1%E3%83%B3%E3%82%BF%E3%83%AB+&+Major+Lazer/_/Let+Me+Live+(feat.+Anne-Marie+&+Mr+Eazi)",
+        "name": "Let Me Live (feat. Anne-Marie & Mr Eazi)",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246",
+          "name": "乃木坂46",
+          "mbid": "466f7b0a-a3e6-435d-8326-b4ef825a609d"
+        },
+        "date": {
+          "uts": "1535292963",
+          "#text": "26 Aug 2018, 14:16"
+        },
+        "mbid": "07be8fbe-615f-4d8d-a74a-8a728dd539c1",
+        "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246/_/%E3%82%B8%E3%82%B3%E3%83%81%E3%83%A5%E3%83%BC%E3%81%A7%E8%A1%8C%E3%81%93%E3%81%86!",
+        "name": "ジコチューで行こう!",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246",
+          "name": "乃木坂46",
+          "mbid": "466f7b0a-a3e6-435d-8326-b4ef825a609d"
+        },
+        "date": {
+          "uts": "1524392729",
+          "#text": "22 Apr 2018, 10:25"
+        },
+        "mbid": "1c8ef45e-1fe2-46fc-8932-8a15b5a86928",
+        "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246/_/%E8%A8%80%E9%9C%8A%E7%A0%B2",
+        "name": "言霊砲",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246",
+          "name": "乃木坂46",
+          "mbid": "466f7b0a-a3e6-435d-8326-b4ef825a609d"
+        },
+        "date": {
+          "uts": "1524233440",
+          "#text": "20 Apr 2018, 14:10"
+        },
+        "mbid": "2b89343c-f21b-4821-a7db-c32e7e2e704a",
+        "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246/_/%E7%BE%BD%E6%A0%B9%E3%81%AE%E8%A8%98%E6%86%B6",
+        "name": "羽根の記憶",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246",
+          "name": "乃木坂46",
+          "mbid": "466f7b0a-a3e6-435d-8326-b4ef825a609d"
+        },
+        "date": {
+          "uts": "1524233439",
+          "#text": "20 Apr 2018, 14:10"
+        },
+        "mbid": "6d6a440e-3625-4aab-9c11-fcf0260e6aa7",
+        "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246/_/%E3%82%B7%E3%83%B3%E3%82%AF%E3%83%AD%E3%83%8B%E3%82%B7%E3%83%86%E3%82%A3",
+        "name": "シンクロニシティ",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246",
+          "name": "乃木坂46",
+          "mbid": "466f7b0a-a3e6-435d-8326-b4ef825a609d"
+        },
+        "date": {
+          "uts": "1522572130",
+          "#text": "01 Apr 2018, 08:42"
+        },
+        "mbid": "4b35cc77-4453-4483-9faa-2a4384e96e9c",
+        "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246/_/%E3%83%AD%E3%83%9E%E3%83%B3%E3%82%B9%E3%81%AE%E3%82%B9%E3%82%BF%E3%83%BC%E3%83%88",
+        "name": "ロマンスのスタート",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/Tritonal",
+          "name": "Tritonal",
+          "mbid": "bbee6bad-1904-460e-b9f7-9e61fc890673"
+        },
+        "date": {
+          "uts": "1522572119",
+          "#text": "01 Apr 2018, 08:41"
+        },
+        "mbid": "",
+        "url": "https://www.last.fm/music/Tritonal/_/Good+Thing+(feat.+Laurell)+%5BVigel+Remix%5D",
+        "name": "Good Thing (feat. Laurell) [Vigel Remix]",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/Clean+Bandit",
+          "name": "Clean Bandit",
+          "mbid": "dacc2d64-7e59-42a8-87a9-10c53919aff2"
+        },
+        "date": {
+          "uts": "1522572118",
+          "#text": "01 Apr 2018, 08:41"
+        },
+        "mbid": "",
+        "url": "https://www.last.fm/music/Clean+Bandit/_/Symphony+(feat.+Zara+Larsson)+%5BDash+Berlin+Remix%5D",
+        "name": "Symphony (feat. Zara Larsson) [Dash Berlin Remix]",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/Samurah",
+          "name": "Samurah",
+          "mbid": ""
+        },
+        "date": {
+          "uts": "1522570458",
+          "#text": "01 Apr 2018, 08:14"
+        },
+        "mbid": "",
+        "url": "https://www.last.fm/music/Samurah/_/No+Problem+(feat.+Tori+Franco)",
+        "name": "No Problem (feat. Tori Franco)",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246",
+          "name": "乃木坂46",
+          "mbid": "466f7b0a-a3e6-435d-8326-b4ef825a609d"
+        },
+        "date": {
+          "uts": "1515414204",
+          "#text": "08 Jan 2018, 12:23"
+        },
+        "mbid": "",
+        "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246/_/%E8%A3%B8%E8%B6%B3%E3%81%A7Summer",
+        "name": "裸足でSummer",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246",
+          "name": "乃木坂46",
+          "mbid": "466f7b0a-a3e6-435d-8326-b4ef825a609d"
+        },
+        "date": {
+          "uts": "1515414201",
+          "#text": "08 Jan 2018, 12:23"
+        },
+        "mbid": "2b6264c4-97fc-4e6d-8d47-0415fc33b404",
+        "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246/_/%E5%83%95%E3%81%A0%E3%81%91%E3%81%AE%E5%85%89",
+        "name": "僕だけの光",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246",
+          "name": "乃木坂46",
+          "mbid": "466f7b0a-a3e6-435d-8326-b4ef825a609d"
+        },
+        "date": {
+          "uts": "1515414200",
+          "#text": "08 Jan 2018, 12:23"
+        },
+        "mbid": "272b3923-c60c-4a60-8bfe-19f6aebc1fe9",
+        "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246/_/%E5%85%89%E5%90%88%E6%88%90%E5%B8%8C%E6%9C%9B",
+        "name": "光合成希望",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246",
+          "name": "乃木坂46",
+          "mbid": "466f7b0a-a3e6-435d-8326-b4ef825a609d"
+        },
+        "date": {
+          "uts": "1515303013",
+          "#text": "07 Jan 2018, 05:30"
+        },
+        "mbid": "2b6e8ae9-7166-4081-a7cd-805a7eaaa0af",
+        "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246/_/%E4%B8%96%E7%95%8C%E3%81%A7%E4%B8%80%E7%95%AA+%E5%AD%A4%E7%8B%AC%E3%81%AALover",
+        "name": "世界で一番 孤独なLover",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E5%AE%89%E5%AE%A4%E5%A5%88%E7%BE%8E%E6%81%B5",
+          "name": "安室奈美恵",
+          "mbid": "888994e5-6f53-4f53-bced-b20482aea42a"
+        },
+        "date": {
+          "uts": "1515302988",
+          "#text": "07 Jan 2018, 05:29"
+        },
+        "mbid": "2aeab771-cc7e-4261-987e-58a092da7c59",
+        "url": "https://www.last.fm/music/%E5%AE%89%E5%AE%A4%E5%A5%88%E7%BE%8E%E6%81%B5/_/Showtime",
+        "name": "Showtime",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246",
+          "name": "乃木坂46",
+          "mbid": "466f7b0a-a3e6-435d-8326-b4ef825a609d"
+        },
+        "date": {
+          "uts": "1515302956",
+          "#text": "07 Jan 2018, 05:29"
+        },
+        "mbid": "0681691e-d9a4-42c7-a376-6faae96e0ca7",
+        "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246/_/%E3%83%9D%E3%83%94%E3%83%91%E3%83%83%E3%83%91%E3%83%91%E3%83%BC",
+        "name": "ポピパッパパー",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246",
+          "name": "乃木坂46",
+          "mbid": "466f7b0a-a3e6-435d-8326-b4ef825a609d"
+        },
+        "date": {
+          "uts": "1515302915",
+          "#text": "07 Jan 2018, 05:28"
+        },
+        "mbid": "65722cd8-700b-4a0a-9fb8-140777ef0c22",
+        "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246/_/%E3%82%B7%E3%83%BC%E3%82%AF%E3%83%AC%E3%83%83%E3%83%88%E3%82%B0%E3%83%A9%E3%83%95%E3%82%A3%E3%83%86%E3%82%A3%E3%83%BC",
+        "name": "シークレットグラフィティー",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246",
+          "name": "乃木坂46",
+          "mbid": "466f7b0a-a3e6-435d-8326-b4ef825a609d"
+        },
+        "date": {
+          "uts": "1515302902",
+          "#text": "07 Jan 2018, 05:28"
+        },
+        "mbid": "21d2ff88-50b8-4035-975a-c1674f78efff",
+        "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246/_/%E3%83%AD%E3%83%9E%E3%83%B3%E3%83%86%E3%82%A3%E3%83%83%E3%82%AF%E3%81%84%E3%81%8B%E7%84%BC%E3%81%8D",
+        "name": "ロマンティックいか焼き",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246",
+          "name": "乃木坂46",
+          "mbid": "466f7b0a-a3e6-435d-8326-b4ef825a609d"
+        },
+        "date": {
+          "uts": "1515302878",
+          "#text": "07 Jan 2018, 05:27"
+        },
+        "mbid": "31a85d31-8e06-485c-8c71-988366a24fe2",
+        "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246/_/%E3%82%AA%E3%83%95%E3%82%B7%E3%83%A7%E3%82%A2%E3%82%AC%E3%83%BC%E3%83%AB",
+        "name": "オフショアガール",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/Power+Music+Workout",
+          "name": "Power Music Workout",
+          "mbid": ""
+        },
+        "date": {
+          "uts": "1514725053",
+          "#text": "31 Dec 2017, 12:57"
+        },
+        "mbid": "",
+        "url": "https://www.last.fm/music/Power+Music+Workout/_/Havana+(Workout+Mix)",
+        "name": "Havana (Workout Mix)",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/Power+Music+Workout",
+          "name": "Power Music Workout",
+          "mbid": ""
+        },
+        "date": {
+          "uts": "1514725049",
+          "#text": "31 Dec 2017, 12:57"
+        },
+        "mbid": "",
+        "url": "https://www.last.fm/music/Power+Music+Workout/_/Rockabye+(Workout+Mix+128+BPM)",
+        "name": "Rockabye (Workout Mix 128 BPM)",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246",
+          "name": "乃木坂46",
+          "mbid": "466f7b0a-a3e6-435d-8326-b4ef825a609d"
+        },
+        "date": {
+          "uts": "1514725047",
+          "#text": "31 Dec 2017, 12:57"
+        },
+        "mbid": "ec5eb5db-5eab-4ec1-a54e-75572fa08fca",
+        "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246/_/%E9%80%83%E3%81%92%E6%B0%B4",
+        "name": "逃げ水",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/Power+Music+Workout",
+          "name": "Power Music Workout",
+          "mbid": ""
+        },
+        "date": {
+          "uts": "1514725046",
+          "#text": "31 Dec 2017, 12:57"
+        },
+        "mbid": "",
+        "url": "https://www.last.fm/music/Power+Music+Workout/_/That%27s+What+I+Like+(Workout+Mix+135+BPM)",
+        "name": "That's What I Like (Workout Mix 135 BPM)",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E6%AC%85%E5%9D%8246",
+          "name": "欅坂46",
+          "mbid": "0ba820db-bb50-4650-a515-d9ba80bf6d34"
+        },
+        "date": {
+          "uts": "1510487486",
+          "#text": "12 Nov 2017, 11:51"
+        },
+        "mbid": "",
+        "url": "https://www.last.fm/music/%E6%AC%85%E5%9D%8246/_/%E6%B2%88%E9%BB%99%E3%81%97%E3%81%9F%E6%81%8B%E4%BA%BA%E3%82%88",
+        "name": "沈黙した恋人よ",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246",
+          "name": "乃木坂46",
+          "mbid": "466f7b0a-a3e6-435d-8326-b4ef825a609d"
+        },
+        "date": {
+          "uts": "1507989107",
+          "#text": "14 Oct 2017, 13:51"
+        },
+        "mbid": "02436df7-55f4-4884-896a-339f0900b336",
+        "url": "https://www.last.fm/music/%E4%B9%83%E6%9C%A8%E5%9D%8246/_/%E4%B8%89%E7%95%AA%E7%9B%AE%E3%81%AE%E9%A2%A8",
+        "name": "三番目の風",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/Maggie+Lindemann",
+          "name": "Maggie Lindemann",
+          "mbid": "8facd4ef-bd7e-4ad1-b0bd-42e59017ce0f"
+        },
+        "date": {
+          "uts": "1507989102",
+          "#text": "14 Oct 2017, 13:51"
+        },
+        "mbid": "0efeb64f-f565-4b67-b3e1-42713cc47d13",
+        "url": "https://www.last.fm/music/Maggie+Lindemann/_/Pretty+Girl+(Cheat+Codes+X+Cade+Remix)",
+        "name": "Pretty Girl (Cheat Codes X Cade Remix)",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E6%AC%85%E5%9D%8246",
+          "name": "欅坂46",
+          "mbid": "0ba820db-bb50-4650-a515-d9ba80bf6d34"
+        },
+        "date": {
+          "uts": "1507989094",
+          "#text": "14 Oct 2017, 13:51"
+        },
+        "mbid": "",
+        "url": "https://www.last.fm/music/%E6%AC%85%E5%9D%8246/_/%E5%A4%AA%E9%99%BD%E3%81%AF%E8%A6%8B%E4%B8%8A%E3%81%92%E3%82%8B%E4%BA%BA%E3%82%92%E9%81%B8%E3%81%B0%E3%81%AA%E3%81%84",
+        "name": "太陽は見上げる人を選ばない",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/%E6%AC%85%E5%9D%8246",
+          "name": "欅坂46",
+          "mbid": "0ba820db-bb50-4650-a515-d9ba80bf6d34"
+        },
+        "date": {
+          "uts": "1505740408",
+          "#text": "18 Sep 2017, 13:13"
+        },
+        "mbid": "276af3e4-9953-4c4a-84f0-b9f82bfbe3bc",
+        "url": "https://www.last.fm/music/%E6%AC%85%E5%9D%8246/_/%E5%8D%B1%E3%81%AA%E3%81%A3%E3%81%8B%E3%81%97%E3%81%84%E8%A8%88%E7%94%BB",
+        "name": "危なっかしい計画",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/Power+Music+Workout",
+          "name": "Power Music Workout",
+          "mbid": ""
+        },
+        "date": {
+          "uts": "1504585983",
+          "#text": "05 Sep 2017, 04:33"
+        },
+        "mbid": "",
+        "url": "https://www.last.fm/music/Power+Music+Workout/_/Mama+(Workout+Mix+141+BPM)",
+        "name": "Mama (Workout Mix 141 BPM)",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/PassCode",
+          "name": "PassCode",
+          "mbid": "2b875bcd-6f09-4b70-87fc-17d3f17e6097"
+        },
+        "date": {
+          "uts": "1502631165",
+          "#text": "13 Aug 2017, 13:32"
+        },
+        "mbid": "",
+        "url": "https://www.last.fm/music/PassCode/_/Scarlet+Night",
+        "name": "Scarlet Night",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/LMFAO",
+          "name": "LMFAO",
+          "mbid": "ed5d9086-e8cd-473a-b96c-d81ad6c98f0d"
+        },
+        "date": {
+          "uts": "1502542337",
+          "#text": "12 Aug 2017, 12:52"
+        },
+        "mbid": "d049fd9b-faa2-429c-9b56-ceeeaacc17e8",
+        "url": "https://www.last.fm/music/LMFAO/_/Shots",
+        "name": "Shots",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/PassCode",
+          "name": "PassCode",
+          "mbid": "2b875bcd-6f09-4b70-87fc-17d3f17e6097"
+        },
+        "date": {
+          "uts": "1502013774",
+          "#text": "06 Aug 2017, 10:02"
+        },
+        "mbid": "20fedf70-8e41-4417-8524-e34eb5a4f04c",
+        "url": "https://www.last.fm/music/PassCode/_/Same+to+you",
+        "name": "Same to you",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/PassCode",
+          "name": "PassCode",
+          "mbid": "2b875bcd-6f09-4b70-87fc-17d3f17e6097"
+        },
+        "date": {
+          "uts": "1502008152",
+          "#text": "06 Aug 2017, 08:29"
+        },
+        "mbid": "1055527a-3873-44e4-ab12-469278b902f8",
+        "url": "https://www.last.fm/music/PassCode/_/Insanity",
+        "name": "Insanity",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/PassCode",
+          "name": "PassCode",
+          "mbid": "2b875bcd-6f09-4b70-87fc-17d3f17e6097"
+        },
+        "date": {
+          "uts": "1499341505",
+          "#text": "06 Jul 2017, 11:45"
+        },
+        "mbid": "b0824bf2-28b7-4459-8e5d-238f7bcf2c13",
+        "url": "https://www.last.fm/music/PassCode/_/ONE+STEP+BEYOND",
+        "name": "ONE STEP BEYOND",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/Power+Music+Workout",
+          "name": "Power Music Workout",
+          "mbid": ""
+        },
+        "date": {
+          "uts": "1498921156",
+          "#text": "01 Jul 2017, 14:59"
+        },
+        "mbid": "",
+        "url": "https://www.last.fm/music/Power+Music+Workout/_/There%27s+Nothing+Holdin%27+Me+Back+(Workout+Mix+143+BPM)",
+        "name": "There's Nothing Holdin' Me Back (Workout Mix 143 BPM)",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      },
+      {
+        "artist": {
+          "url": "https://www.last.fm/music/Power+Music+Workout",
+          "name": "Power Music Workout",
+          "mbid": ""
+        },
+        "date": {
+          "uts": "1498921154",
+          "#text": "01 Jul 2017, 14:59"
+        },
+        "mbid": "",
+        "url": "https://www.last.fm/music/Power+Music+Workout/_/Something+Just+Like+This+(Workout+Mix+139+BPM)",
+        "name": "Something Just Like This (Workout Mix 139 BPM)",
+        "image": [
+          {
+            "size": "small",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/34s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "medium",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "large",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
+          },
+          {
+            "size": "extralarge",
+            "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+          }
+        ],
+        "streamable": {
+          "fulltrack": "0",
+          "#text": "0"
+        }
+      }
+    ],
+    "@attr": {
+      "user": "matakucom",
+      "totalPages": "2",
+      "page": "1",
+      "perPage": "50",
+      "total": "67"
+    }
+  }
+}

--- a/app/src/androidTest/java/com/mataku/scrobscrob/app/testing/DataStoreReset.kt
+++ b/app/src/androidTest/java/com/mataku/scrobscrob/app/testing/DataStoreReset.kt
@@ -1,0 +1,11 @@
+package com.mataku.scrobscrob.app.testing
+
+import android.content.Context
+
+internal fun resetDataStores(context: Context) {
+  val datastoreDir = context.filesDir.resolve("datastore")
+  if (!datastoreDir.exists()) return
+  datastoreDir.listFiles()?.forEach { file ->
+    if (file.isFile) file.delete()
+  }
+}

--- a/app/src/androidTest/java/com/mataku/scrobscrob/app/testing/MetroTestRunner.kt
+++ b/app/src/androidTest/java/com/mataku/scrobscrob/app/testing/MetroTestRunner.kt
@@ -1,0 +1,13 @@
+package com.mataku.scrobscrob.app.testing
+
+import android.app.Application
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
+
+class MetroTestRunner : AndroidJUnitRunner() {
+  override fun newApplication(
+    cl: ClassLoader?,
+    className: String?,
+    context: Context?,
+  ): Application = super.newApplication(cl, TestApp::class.java.name, context)
+}

--- a/app/src/androidTest/java/com/mataku/scrobscrob/app/testing/SmokeFlowTest.kt
+++ b/app/src/androidTest/java/com/mataku/scrobscrob/app/testing/SmokeFlowTest.kt
@@ -1,0 +1,46 @@
+package com.mataku.scrobscrob.app.testing
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.platform.app.InstrumentationRegistry
+import com.mataku.scrobscrob.app.ui.top.MainActivity
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class SmokeFlowTest {
+
+  @get:Rule
+  val composeRule = createAndroidComposeRule<MainActivity>()
+
+  @Before
+  fun resetState() {
+    val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+    resetDataStores(targetContext)
+  }
+
+  @Test
+  fun login_redirects_to_home() {
+    composeRule.waitUntilExactlyOneExists(hasText("Let me in!"), TIMEOUT_MS)
+
+    composeRule.onAllNodes(hasSetTextAction()).onFirst().performTextInput("e2e_user")
+    composeRule.onAllNodes(hasSetTextAction())[1].performTextInput("e2e_password")
+
+    composeRule.onNodeWithText("Let me in!").performClick()
+
+    composeRule.waitUntilExactlyOneExists(hasText("Home"), TIMEOUT_MS)
+    composeRule.onNodeWithText("Home").assertIsDisplayed()
+  }
+
+  private companion object {
+    const val TIMEOUT_MS = 10_000L
+  }
+}

--- a/app/src/androidTest/java/com/mataku/scrobscrob/app/testing/TestApp.kt
+++ b/app/src/androidTest/java/com/mataku/scrobscrob/app/testing/TestApp.kt
@@ -1,0 +1,10 @@
+package com.mataku.scrobscrob.app.testing
+
+import com.mataku.scrobscrob.app.App
+import com.mataku.scrobscrob.app.di.AppGraphContract
+import dev.zacsweers.metro.createGraphFactory
+
+class TestApp : App() {
+  override fun newAppGraph(): AppGraphContract =
+    createGraphFactory<TestAppGraph.Factory>().create(this)
+}

--- a/app/src/androidTest/java/com/mataku/scrobscrob/app/testing/TestAppGraph.kt
+++ b/app/src/androidTest/java/com/mataku/scrobscrob/app/testing/TestAppGraph.kt
@@ -1,0 +1,24 @@
+package com.mataku.scrobscrob.app.testing
+
+import android.app.Application
+import android.content.Context
+import com.mataku.scrobscrob.app.di.AppGraphContract
+import com.mataku.scrobscrob.data.api.di.HttpEngineModule
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.DependencyGraph
+import dev.zacsweers.metro.Provides
+
+@DependencyGraph(
+  scope = AppScope::class,
+  excludes = [HttpEngineModule::class]
+)
+internal interface TestAppGraph : AppGraphContract {
+
+  @Provides
+  fun provideApplicationContext(application: Application): Context = application
+
+  @DependencyGraph.Factory
+  fun interface Factory {
+    fun create(@Provides application: Application): TestAppGraph
+  }
+}

--- a/app/src/androidTest/java/com/mataku/scrobscrob/app/testing/di/MockApiModule.kt
+++ b/app/src/androidTest/java/com/mataku/scrobscrob/app/testing/di/MockApiModule.kt
@@ -1,0 +1,26 @@
+package com.mataku.scrobscrob.app.testing.di
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.mataku.scrobscrob.app.testing.fixtures.FixtureDispatcher
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.mock.MockEngine
+
+@ContributesTo(AppScope::class)
+interface MockApiModule {
+  companion object {
+    @SingleIn(AppScope::class)
+    @Provides
+    fun provideHttpClientEngine(): HttpClientEngine {
+      val dispatcher = FixtureDispatcher(
+        InstrumentationRegistry.getInstrumentation().context.assets
+      )
+      return MockEngine { request ->
+        with(dispatcher) { dispatch(request) }
+      }
+    }
+  }
+}

--- a/app/src/androidTest/java/com/mataku/scrobscrob/app/testing/fixtures/FixtureDispatcher.kt
+++ b/app/src/androidTest/java/com/mataku/scrobscrob/app/testing/fixtures/FixtureDispatcher.kt
@@ -1,0 +1,49 @@
+package com.mataku.scrobscrob.app.testing.fixtures
+
+import android.content.res.AssetManager
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.HttpResponseData
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+
+class FixtureDispatcher(private val assets: AssetManager) {
+
+  fun MockRequestHandleScope.dispatch(request: HttpRequestData): HttpResponseData {
+    val method = request.url.parameters["method"].orEmpty()
+    val fixture = method.fixtureName()?.let { name ->
+      runCatching { readAsset(name) }.getOrNull()
+    }
+    return if (fixture == null) {
+      respondError(
+        HttpStatusCode.NotImplemented,
+        "No fixture for method=$method (path=${request.url.encodedPath})"
+      )
+    } else {
+      respond(
+        content = ByteReadChannel(fixture),
+        status = HttpStatusCode.OK,
+        headers = headersOf(HttpHeaders.ContentType, "application/json")
+      )
+    }
+  }
+
+  private fun readAsset(path: String): String =
+    assets.open(path).bufferedReader().use { it.readText() }
+
+  private fun String.fixtureName(): String? = when (lowercase()) {
+    "auth.getmobilesession" -> "mobile_session.json"
+    "user.getrecenttracks" -> "recent_tracks.json"
+    "user.getinfo" -> "user_get_info.json"
+    "user.gettopalbums" -> "top_albums.json"
+    "user.gettopartists" -> "top_artists.json"
+    "user.getlovedtracks" -> "user_loved_tracks.json"
+    "chart.gettoptracks" -> "chart_top_tracks.json"
+    "chart.gettopartists" -> "chart_top_artists.json"
+    else -> null
+  }
+}

--- a/app/src/main/java/com/mataku/scrobscrob/app/App.kt
+++ b/app/src/main/java/com/mataku/scrobscrob/app/App.kt
@@ -6,6 +6,7 @@ import coil3.ImageLoader
 import coil3.SingletonImageLoader
 import com.mataku.scrobscrob.BuildConfig
 import com.mataku.scrobscrob.app.di.AppGraph
+import com.mataku.scrobscrob.app.di.AppGraphContract
 import com.mataku.scrobscrob.data.repository.NowPlayingRepository
 import com.mataku.scrobscrob.data.repository.ScrobbleRepository
 import com.mataku.scrobscrob.data.repository.ScrobbleSettingRepository
@@ -18,7 +19,10 @@ import timber.log.Timber
 
 open class App : Application(), MetroApplication, SingletonImageLoader.Factory, ScrobbleServiceDependencies {
 
-  internal val appGraph: AppGraph by lazy { createGraphFactory<AppGraph.Factory>().create(this) }
+  internal val appGraph: AppGraphContract by lazy { newAppGraph() }
+
+  internal open fun newAppGraph(): AppGraphContract =
+    createGraphFactory<AppGraph.Factory>().create(this)
 
   override val appComponentProviders: MetroAppComponentProviders
     get() = appGraph

--- a/app/src/main/java/com/mataku/scrobscrob/app/di/AppGraph.kt
+++ b/app/src/main/java/com/mataku/scrobscrob/app/di/AppGraph.kt
@@ -10,10 +10,16 @@ import dev.zacsweers.metro.Provides
 import dev.zacsweers.metrox.android.MetroAppComponentProviders
 import dev.zacsweers.metrox.viewmodel.ViewModelGraph
 
-@DependencyGraph(AppScope::class)
-internal interface AppGraph : MetroAppComponentProviders, ViewModelGraph, ScrobbleServiceDependencies {
+internal interface AppGraphContract :
+  MetroAppComponentProviders,
+  ViewModelGraph,
+  ScrobbleServiceDependencies {
 
   val imageLoader: ImageLoader
+}
+
+@DependencyGraph(AppScope::class)
+internal interface AppGraph : AppGraphContract {
 
   @Provides
   fun provideApplicationContext(application: Application): Context = application

--- a/architecture-spec/src/test/kotlin/com/mataku/scrobscrob/architecture/ViewModelArchitectureSpec.kt
+++ b/architecture-spec/src/test/kotlin/com/mataku/scrobscrob/architecture/ViewModelArchitectureSpec.kt
@@ -37,5 +37,48 @@ class ViewModelArchitectureSpec : DescribeSpec({
           }
         }
     }
+
+    it("AndroidViewModel-derived ViewModels pin the bound type via `binding = binding<ViewModel>()`") {
+      scope.classes()
+        .withNameEndingWith("ViewModel")
+        .filter { it.resideInPackage("com.mataku.scrobscrob..") }
+        .filter { vm -> vm.hasParent { parent -> parent.name == "AndroidViewModel" } }
+        .assertTrue(
+          additionalMessage = "ViewModels extending AndroidViewModel must declare " +
+            "`@ContributesIntoMap(AppScope::class, binding = binding<ViewModel>())`. Without " +
+            "the `binding` argument Metro contributes them into a `Map<_, AndroidViewModel>` " +
+            "multibinding that `MetroViewModelFactory` never reads, so the VM silently drops " +
+            "out of the graph and `metroViewModel<T>()` fails at runtime. CLAUDE.md Rule 3.",
+        ) { vm ->
+          val annotation = vm.annotations.firstOrNull { it.name == "ContributesIntoMap" }
+            ?: return@assertTrue false
+          annotation.arguments.any { it.name == "binding" }
+        }
+    }
+
+    it("`@AssistedInject` ViewModels expose a Factory : ViewModelAssistedFactory with the required annotations") {
+      scope.classes()
+        .withNameEndingWith("ViewModel")
+        .filter { it.resideInPackage("com.mataku.scrobscrob..") }
+        .filter { vm -> vm.annotations.any { it.name == "AssistedInject" } }
+        .assertTrue(
+          additionalMessage = "AssistedInject ViewModels must declare a nested " +
+            "`Factory : ViewModelAssistedFactory` annotated with `@AssistedFactory`, " +
+            "`@ViewModelAssistedFactoryKey(<this>::class)`, and " +
+            "`@ContributesIntoMap(AppScope::class)`. Missing any of the three causes the " +
+            "Factory to drop out of the assisted-factory multibinding and " +
+            "`metroViewModel<T>()` fails at runtime. CLAUDE.md Rule 3.",
+        ) { vm ->
+          val factory = vm.interfaces(includeNested = true)
+            .firstOrNull { intf ->
+              intf.hasParent { parent -> parent.name == "ViewModelAssistedFactory" }
+            }
+            ?: return@assertTrue false
+          val annotationNames = factory.annotations.map { it.name }
+          "AssistedFactory" in annotationNames &&
+            "ViewModelAssistedFactoryKey" in annotationNames &&
+            "ContributesIntoMap" in annotationNames
+        }
+    }
   }
 })

--- a/data/api/src/main/java/com/mataku/scrobscrob/data/api/di/ApiModule.kt
+++ b/data/api/src/main/java/com/mataku/scrobscrob/data/api/di/ApiModule.kt
@@ -9,12 +9,11 @@ import coil3.request.crossfade
 import com.mataku.scrobscrob.data.api.BuildConfig
 import com.mataku.scrobscrob.data.api.LastFmHttpClient
 import com.mataku.scrobscrob.data.api.LastFmService
-import com.mataku.scrobscrob.data.api.okhttp.LastfmApiAuthInterceptor
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
-import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.engine.HttpClientEngine
 import okhttp3.Cache
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -45,17 +44,10 @@ interface ApiModule {
   @SingleIn(AppScope::class)
   @Provides
   fun provideLastFmService(
-    okHttpClient: OkHttpClient
-  ): LastFmService {
-    val okHttpEngine = OkHttp.create {
-      preconfigured = okHttpClient.newBuilder()
-        .addInterceptor(LastfmApiAuthInterceptor())
-        .build()
-    }
-    return LastFmService(
-      LastFmHttpClient.create(okHttpEngine)
-    )
-  }
+    engine: HttpClientEngine
+  ): LastFmService = LastFmService(
+    LastFmHttpClient.create(engine)
+  )
 
   @SingleIn(AppScope::class)
   @Provides

--- a/data/api/src/main/java/com/mataku/scrobscrob/data/api/di/HttpEngineModule.kt
+++ b/data/api/src/main/java/com/mataku/scrobscrob/data/api/di/HttpEngineModule.kt
@@ -1,0 +1,24 @@
+package com.mataku.scrobscrob.data.api.di
+
+import com.mataku.scrobscrob.data.api.okhttp.LastfmApiAuthInterceptor
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.okhttp.OkHttp
+import okhttp3.OkHttpClient
+
+@ContributesTo(AppScope::class)
+interface HttpEngineModule {
+  companion object {
+    @SingleIn(AppScope::class)
+    @Provides
+    fun provideHttpClientEngine(okHttpClient: OkHttpClient): HttpClientEngine =
+      OkHttp.create {
+        preconfigured = okHttpClient.newBuilder()
+          .addInterceptor(LastfmApiAuthInterceptor())
+          .build()
+      }
+  }
+}

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -1,0 +1,134 @@
+# E2E Testing
+
+Smoke-level instrumentation tests that drive the real APK against a mocked
+Last.fm API. The goal is "does the app still launch, log in, and render core
+screens" — anything finer-grained belongs in unit tests or Roborazzi screenshot
+tests (see [`testing.md`](testing.md)).
+
+Lives in `app/src/androidTest/`. Runs weekly on CI via
+`.github/workflows/e2e_test.yml` (also `workflow_dispatch`).
+
+## Commands
+
+| Action | Command |
+|--------|---------|
+| Run locally on a connected emulator | `./gradlew :app:connectedDebugAndroidTest` |
+| Build the test APK only | `./gradlew :app:assembleDebugAndroidTest` |
+
+## Architecture
+
+The instrumentation test process loads a `TestApp` instead of the production
+`App`. `TestApp` builds a `TestAppGraph` that excludes the production
+`HttpClientEngine` provider and contributes a `MockEngine` that serves canned
+JSON from `assets/`.
+
+```
+MetroTestRunner (testInstrumentationRunner)
+  └─ newApplication() ─► TestApp
+                          └─ newAppGraph() ─► TestAppGraph
+                                                ├─ excludes HttpEngineModule
+                                                └─ includes MockApiModule (MockEngine)
+                                                                    └─ FixtureDispatcher
+                                                                          └─ assets/*.json
+```
+
+Production-side hooks that make this possible:
+
+- **`AppGraphContract`** (in `app/.../di/AppGraph.kt`) — neutral supertype
+  shared by `AppGraph` and `TestAppGraph`. `App.appGraph` is typed against this
+  contract so test/prod graphs are interchangeable.
+- **`App.newAppGraph()`** is `internal open` — `TestApp` overrides it.
+- **`HttpEngineModule`** (in `data/api/.../di/`) is a separate
+  `@ContributesTo(AppScope::class)` interface whose only job is to provide
+  `HttpClientEngine`. Keeping it in its own binding container is what lets
+  `TestAppGraph` exclude *only* the engine binding without touching the rest of
+  `ApiModule`.
+
+## Adding a fixture for a new endpoint
+
+1. Find the Last.fm API method string the endpoint sends. e.g.
+   `chart.getTopTracks` → `chart.gettoptracks` (lowercased URL parameter).
+2. Drop a JSON file under one of these locations (precedence matches asset
+   merge order in `app/build.gradle.kts`):
+   - `app/src/test/assets/` — preferred when the same fixture is also useful
+     for unit tests (this dir is shared into androidTest's classpath).
+   - `app/src/androidTest/assets/` — e2e-only fixtures.
+   For realistic data, prefer copying from an existing `*RepositorySpec.kt` or
+   `data/api/src/test/assets/`. Real captured payloads catch parsing drift that
+   a hand-written stub won't.
+3. Map the method to the file in `FixtureDispatcher.fixtureName()`:
+   ```kotlin
+   "chart.gettoptracks" -> "chart_top_tracks.json"
+   ```
+4. Comparisons use `lowercase()`, so the URL casing (`getTopTracks` vs
+   `gettoptracks`) doesn't matter — match against the lowercased form.
+
+If a request hits an unmapped method, the dispatcher returns `501 Not
+Implemented` with the method name in the body. That surfaces in the test as a
+parse failure / empty UI, which is usually loud enough to find.
+
+## Adding a new flow to `SmokeFlowTest`
+
+```kotlin
+@Test
+fun some_flow() {
+  composeRule.waitUntilExactlyOneExists(hasText("anchor"), TIMEOUT_MS)
+  // interactions
+}
+```
+
+Conventions used by the existing flow:
+
+- `@Before resetState()` calls `resetDataStores()` so previous runs don't leak
+  a logged-in session into the next test.
+- Anchor on **hardcoded English** strings (`"Let me in!"`, `"Home"`) rather
+  than on translated `stringResource`s. The CI emulator is en-US by default,
+  but local devices may not be — anchoring on translated text wedges the test
+  on a non-English locale. If a flow has no hardcoded anchor, look up the
+  string via `composeRule.activity.getString(R.string.foo)`.
+- Use `hasSetTextAction()` matchers to drive `SunsetTextField` rather than
+  searching by label — labels are part of a different semantic node from the
+  input field.
+- `TIMEOUT_MS = 10_000L` is generous for emulator boot + first network call.
+  Don't tighten without reason.
+
+## Running on CI
+
+`.github/workflows/e2e_test.yml`:
+- Schedule: `0 18 * * 0` (Sunday 18:00 UTC = Monday 03:00 JST). Also
+  `workflow_dispatch` with a `branch` input.
+- Uses `reactivecircus/android-emulator-runner` on API 34 / x86_64 with an AVD
+  snapshot cached via `actions/cache`. First run primes the snapshot; later
+  runs reuse it.
+- Failures upload `**/build/reports/androidTests/**` and
+  `**/build/outputs/androidTest-results/**` as artifacts (7-day retention).
+
+## Gotchas worth remembering
+
+- **Don't override `android:name` via `tools:replace` in the androidTest
+  manifest.** It looks like the right knob, but it makes the test APK try to
+  instantiate `TestApp` from its *own* package's classloader — which can't see
+  `App` from the main APK. Symptom: `ClassNotFoundException: ...App` (the
+  parent class, not TestApp itself). Use `MetroTestRunner.newApplication`
+  instead — that path goes through `MetroAppComponentFactory` in the target
+  process and resolves both APKs correctly.
+- **Don't share `HttpClientEngine` provider with `ApiModule`'s other
+  bindings.** If `provideHttpClientEngine` lived inside `ApiModule`, excluding
+  it would also kill `provideOkhttpClient` / `provideLastFmService` /
+  `provideImageLoader`. The split into `HttpEngineModule` is what keeps the
+  exclusion surgical.
+- **Compose's `createAndroidComposeRule` (v1)** is deprecated in favour of v2
+  but still works. The v2 API uses `StandardTestDispatcher` which changes
+  coroutine ordering — migrate intentionally, not casually.
+
+## What's intentionally not covered
+
+- Production API drift. The mock returns whatever JSON we last captured; if
+  Last.fm changes a schema, this suite happily passes. Catching that needs a
+  separate (non-weekly, opt-in) job that hits the real API.
+- Login error paths, edge cases, deep-linked navigation. Those live in unit /
+  screenshot tests where they're cheaper.
+- `feature:account` Play Store / file-system dependencies. They aren't mocked
+  — the screen happens to render fine without `appUpdateInfo`, but if a future
+  account flow blocks on Play Core, plan to provide a fake `AppUpdateManager`
+  in `MockApiModule`.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,6 +85,7 @@ sqldelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions", 
 
 androidx-test-core = { module = "androidx.test:core", version = "1.6.1" }
 androidx-test-ext-junit = { module = "androidx.test.ext:junit", version = "1.2.1" }
+androidx-test-runner = { module = "androidx.test:runner", version = "1.6.2" }
 androidx-test-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version = "2.3.0" }
 androidx-benchmark-macro-junit4 = { module = "androidx.benchmark:benchmark-macro-junit4", version = "1.3.3" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }


### PR DESCRIPTION
## Changes

- Split HttpEngineModule out of ApiModule so the engine binding can be excluded from a test graph without affecting other API providers
- Introduce AppGraphContract and App.newAppGraph() to let TestApp swap in a TestAppGraph that excludes HttpEngineModule and contributes a MockEngine via MockApiModule
- Add app/src/androidTest/: MetroTestRunner, TestApp, TestAppGraph, MockApiModule, FixtureDispatcher (URL method= -> assets/*.json), DataStoreReset, and SmokeFlowTest covering login -> home
- Configure androidTest sourceSets to share app/src/test/assets and wire androidx.test:runner, compose-ui-test-junit4, ktor-client-mock, coroutines-test androidTest deps
- Add fixtures for chart.getTopTracks/Artists, user.getLovedTracks, user.getInfo (recent_tracks, top_albums/artists, mobile_session reused from app/src/test/assets)
- Add .github/workflows/e2e_test.yml: Sunday 18:00 UTC cron plus workflow_dispatch, reactivecircus/android-emulator-runner with AVD snapshot cache and androidTest reports artifact on failure
- Document harness, fixture-add procedure, locale gotcha, and manifest tools:replace pitfall in docs/e2e-testing.md and link  it from CLAUDE.md's documentation table